### PR TITLE
Provide a VM for tests, using vagrant and ansible.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 upload-temp/*
-config.php
+/config.php
 banners/*
 adminarea/.htaccess
 adminarea/.htpasswd
 thegamesdb.sublime-workspace
+/.vagrant/
+/tgdb-dev*.sql
+/README.txt

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,17 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.network "forwarded_port", guest: 80, host: 8888
+
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "ansible/playbook.yml"
+    ansible.sudo = true
+  end
+
+  config.vm.synced_folder ".", "/var/www/html", owner: "root", group: "www-data"
+end

--- a/ansible/apache-site.conf
+++ b/ansible/apache-site.conf
@@ -1,0 +1,12 @@
+<VirtualHost *:80>
+	DocumentRoot /var/www/html
+	<Directory /var/www/html/>
+		AllowOverride All
+		Order allow,deny
+		Allow from All
+	</Directory>
+	ErrorLog ${APACHE_LOG_DIR}/error.log 
+	CustomLog ${APACHE_LOG_DIR}/access.log combined 
+</VirtualHost>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/ansible/config.php
+++ b/ansible/config.php
@@ -1,0 +1,24 @@
+<?php
+	## Misc Settings
+	$baseurl = "";
+	$apache_type = "unix";  // Types are unix or windows
+
+	## DB Settings
+	$db_user = "root"; // Database Username
+	$db_password = ""; // Database Password
+	$db_database = "thegamedb"; // Database Name
+	$db_server = "localhost"; // Usually Localhost
+
+	## Mail Settings
+	$mail_server = "localhost";
+	$mail_username = "";
+	$mail_password = "";
+
+	## Recaptcha Settings
+	// (Developers will need to get their own keys from recaptcha, if you are running from 'localhost' try making the key usable for 'all domains')
+	$recpatcha_publickey = "";
+    $recaptcha_privatekey = "";
+
+    ## Timezone Settings
+	date_default_timezone_set('UTC'); 
+?>

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,0 +1,44 @@
+---
+- hosts: all
+  sudo: true
+  tasks:
+    # Install packages:
+    - apt: name="{{item}}" update_cache=yes cache_valid_time=3600 state=present
+      with_items:
+      - libapache2-mod-php5
+      - apache2
+      - mysql-server
+      - php5-mysql
+      - php5-gd
+      - php5-curl
+      - python-mysqldb
+      - unzip
+    # Apache+PHP setup:
+    - copy: dest=/etc/apache2/sites-enabled/thegamesdb.conf src=apache-site.conf owner=root group=root mode=0644
+      notify: apache-restart
+    - file: dest=/etc/apache2/sites-enabled/000-default.conf state=absent
+      notify: apache-restart
+    - lineinfile: dest=/etc/php5/apache2/php.ini line="short_open_tag = On" regexp="^short_open_tag.*"
+      notify: apache-restart
+    - apache2_module: state=present name=rewrite
+      notify: apache-restart
+    - file: dest=/var/www/html/index.html state=absent
+    - copy: src=config.php  dest=/var/www/html/config.php owner=root group=www-data mode=0755
+      notify: apache-restart
+    - service: name=apache2 state=running enabled=yes
+    # mysql+database setup:
+    - service: name=mysql state=started enabled=true
+    - mysql_user: name=root host="{{item}}" password="" login_user=root login_password=root check_implicit_admin=yes priv="*.*:ALL,GRANT"
+      with_items:
+        - "{{ ansible_hostname }}"
+        - 127.0.0.1
+        - ::1
+        - localhost
+    - get_url: url="http://thegamesdb.net/tgdb-dev-pack.zip" dest=/tmp/tgdb-dev-pack.zip sha256sum=e4e72ee24ffb9fbf25ce1cd62a92897ff92cc9d8cad368fc852f571951b926ec
+    - command: unzip -o /tmp/tgdb-dev-pack.zip chdir=/var/www/html
+    - mysql_db: name=thegamedb state=present
+    - shell: cat /var/www/html/tgdb-dev*.sql | mysql -u root thegamedb
+  handlers:
+    - name: apache-restart
+      service: name=apache2 state=restarted
+

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ To get the site to run locally, you will need to install and configure the follo
   <dd>Additional Requirements: Settings - short open tag (on) - Please Note: as of 23/09/2013 "register globals" is no longer required to be enabled... since PHP 5.4 has removed support for this, we had to introduce a Shiv in the code. As a result, you may want to alter your php error reporting settings to not display errors, as several uninitialized variables currently remain in use.</dd>
 </dl>
 
-The quickest way to install and configure these components is by using XAMPP/LAMP on Linux, MAMP on Mac, or XAMPP/WAMP on Windows.
+The quickest way to install and configure these components is by using XAMPP/LAMP on Linux, MAMP on Mac, or XAMPP/WAMP on Windows. You can also use vagrant, as described below.
 
 Once these components are installed you will want to extract the site code into your www or httpdocs directory.
 
@@ -58,3 +58,9 @@ That's It!
 ----------
 
 *Now you should be good to go! Navigate to your web-server's url (typically "http://localhost" for local web-servers such as WAMP/LAMP/MAMP/XAMPP)in your favorite browser and see if it all works!*
+
+Vagrant
+-------
+
+There is a "Vagrantfile" in this repository that can be used to bring up a VirtualBox test VM with the site and the TGDB development pack. It basically follows the instructions provided above inside a base Ubuntu 14.04 installation. Just issue a "vagrant up" and access http://localhost:8888/
+


### PR DESCRIPTION
This commit adds a Vagrantfile that brings up the standard ubuntu/trusty64
vagrant virtualbox VM, provisions it with the required apache, PHP and
MySQL packages and configurations, and installs the site. To do that,
install vagrant on the host and do a "vagrant up" in the working copy
of the repository. The site will be available at http://localhost:8888/