### PR TITLE
Vagrant runs ansible inside the VM instead of in the host.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,10 +8,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.network "forwarded_port", guest: 80, host: 8888
 
-  config.vm.provision "ansible" do |ansible|
-    ansible.playbook = "ansible/playbook.yml"
-    ansible.sudo = true
-  end
+  config.vm.provision "shell", inline: <<-SH
+    set -e -x
+    aptitude update
+    aptitude install -R -y ansible
+    ansible-playbook -i localhost, -c local /var/www/html/ansible/playbook.yml
+  SH
 
   config.vm.synced_folder ".", "/var/www/html", owner: "root", group: "www-data"
 end

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -3,7 +3,7 @@
   sudo: true
   tasks:
     # Install packages:
-    - apt: name="{{item}}" update_cache=yes cache_valid_time=3600 state=present
+    - apt: name="{{item}}" state=present
       with_items:
       - libapache2-mod-php5
       - apache2
@@ -20,7 +20,7 @@
       notify: apache-restart
     - lineinfile: dest=/etc/php5/apache2/php.ini line="short_open_tag = On" regexp="^short_open_tag.*"
       notify: apache-restart
-    - apache2_module: state=present name=rewrite
+    - file: state=link dest=/etc/apache2/mods-enabled/rewrite.load src=/etc/apache2/mods-available/rewrite.load
       notify: apache-restart
     - file: dest=/var/www/html/index.html state=absent
     - copy: src=config.php  dest=/var/www/html/config.php owner=root group=www-data mode=0755


### PR DESCRIPTION
By installing and running insible inside the VM, we avoid
adding it as a dependency on the host, which is specially
important if the host is a Windows machine.